### PR TITLE
Allow RAET to be PIP installable. Fixes #15

### DIFF
--- a/raet/__init__.py
+++ b/raet/__init__.py
@@ -4,13 +4,12 @@ raet modules
 
 __init__.py file for raet package
 '''
-__version__ = "0.0.19"
-__author__ = "Samuel M. Smith"
-__license__ =  "Apache2"
-
 
 __all__ = ['raeting', 'nacling', 'keeping', 'lotting', 'stacking', 'road', 'lane']
 
 import  importlib
 for m in __all__:
     importlib.import_module(".{0}".format(m), package='raet')
+
+# Load the package metadata
+from raet.__metadata__ import *

--- a/raet/__metadata__.py
+++ b/raet/__metadata__.py
@@ -1,0 +1,10 @@
+'''
+Raet package metadata
+'''
+
+__version_info__ = (0, 0, 19)
+__version__ = '{0}.{1}.{2}'.format(*__version_info__)
+__author__ = "Samuel M. Smith"
+__license__ = "Apache2"
+
+__all__ = ['__version_info__', '__version__', '__author__', '__license__']

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,6 @@ import os
 import  sys
 from setuptools import setup, find_packages
 
-import raet
-
 # Change to RAET's source's directory prior to running any command
 try:
     SETUP_DIRNAME = os.path.dirname(__file__)
@@ -32,6 +30,11 @@ RAET_REQS = os.path.join(
     os.path.abspath(SETUP_DIRNAME), 'requirements.txt'
 )
 
+RAET_METADATA = os.path.join(SETUP_DIRNAME, 'raet', '__metadata__.py')
+
+# Load the metadata using exec() in order not to trigger raet.__init__ import
+exec(compile(open(RAET_METADATA).read(), RAET_METADATA, 'exec'))
+
 REQUIREMENTS = []
 with open(RAET_REQS) as rfh:
     for line in rfh.readlines():
@@ -48,15 +51,15 @@ if sys.version_info < (2, 7): #tuple comparison element by element
 
 setup(
     name='raet',
-    version=raet.__version__,
+    version=__version__,
     description='Reliable Asynchronous Event Transport protocol',
     long_description='Asynchronous transaction based protocol'
                      ' using Ioflo. http://ioflo.com',
     url='https://github.com/saltstack/raet',
     download_url='https://github.com/saltstack/raet/archive/master.zip',
-    author=raet.__author__,
+    author=__author__,
     author_email='info@ioflo.com',
-    license=raet.__license__,
+    license=__license__,
     keywords=('UDP UXD Communications CurveCP Elliptic Curve Crypto'
               'Reliable Asynchronous Event Transport Protocol'),
     packages=find_packages(exclude=['test', 'test.*',


### PR DESCRIPTION
Created a new module which holds the package metadata, `__version__`, `__author__`, `__license__`. Additionally added `__version_info__` which allows math based version comparison.
This metadata is still available in `raet.__init__` because we import it there, but more importantly, we can now load this metadata in the setup script without having to load the raet module(`raet.__init__`, which in turn loads all it's
modules which in turn load the dependencies). This way, we allow pip to install the required dependencies before actually needing then.
