### PR TITLE
added suse rpm spec file for python-raet packaging

### DIFF
--- a/pkg/suse/python-raet.changes
+++ b/pkg/suse/python-raet.changes
@@ -1,0 +1,42 @@
+-------------------------------------------------------------------
+Wed Jul  2 18:25:59 UTC 2014 - aboe76@gmail.com
+
+- Major release 0.1.0
+  - Minor fixup prepping for release with SaltStack Release Candidate
+
+-------------------------------------------------------------------
+Tue Jul  1 18:56:32 UTC 2014 - aboe76@gmail.com
+
+- Updated to version 0.0.31:
+  - Fixed roadstack .manage method to used aliveds
+- From versions in between
+  - No longer removes rejected remotes out of band or future presence expire mechanism is needed to 
+  remove rejected remotes 0.0.30
+  - Fixed a bug on renew in Joiner transaction 0.0.29
+  - Fixed some race conditions 0.0.28
+  - Support for reaping and restoring dead remotes on main estate road stack Support for saving and 
+  resending stale messages when session changes on rejoin or reallow Some other fixes 0.0.27
+  - RoadStack.manage now provide underlying support needed for presence events and filtering of remote 
+  targets based on availabilty (allowed) status 0.0.26
+
+-------------------------------------------------------------------
+Sat Jun 21 07:12:41 UTC 2014 - aboe76@gmail.com
+
+- Updated to version 0.0.25
+  fix install_requirements error
+
+-------------------------------------------------------------------
+Fri Jun 20 08:33:21 UTC 2014 - aboe76@gmail.com
+
+- updated to version 0.0.23
+
+-------------------------------------------------------------------
+Wed Jun 18 19:52:44 UTC 2014 - aboe76@gmail.com
+
+- Update to version 0.0.19
+
+-------------------------------------------------------------------
+Mon Jun  9 10:05:11 UTC 2014 - aboe76@gmail.com
+
+- Initial package version 0.0.18
+

--- a/pkg/suse/python-raet.spec
+++ b/pkg/suse/python-raet.spec
@@ -1,0 +1,68 @@
+#
+# spec file for package python-raet
+#
+# Copyright (c) 2014 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+Name:           python-raet
+Version:        0.1.0
+Release:        0
+License:        Apache-2.0
+Summary:        Reliable Asynchronous Event Transport protocol
+Url:            https://github.com/saltstack/raet
+Group:          Development/Languages/Python
+Source0:        https://pypi.python.org/packages/source/r/raet/raet-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/raet-%{version}-build
+
+BuildRequires:  python-setuptools
+BuildRequires:  python-devel
+BuildRequires:  python-six
+BuildRequires:  python-ioflo
+BuildRequires:  python-libnacl
+BuildRequires:  fdupes
+BuildRequires:  libsodium-devel
+Requires:       python-libnacl
+Requires:       python-ioflo
+
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+%if 0%{?suse_version} && 0%{?suse_version} <= 1110
+%{!?python_sitelib: %global python_sitelib %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+BuildRequires:  python-importlib
+Requires: 		python-importlib
+BuildRequires: 	python
+Requires: 		python
+%else
+BuildArch:      noarch
+%endif
+
+%description
+Raet is a Python library for raet protocol which stands for
+Reliable Asynchronous Event Transport protocol.
+
+%prep
+%setup -q -n raet-%{version}
+
+%build
+python setup.py build
+
+%install
+python setup.py install --prefix=%{_prefix} --root=%{buildroot} --optimize=1
+%fdupes %{buildroot}%{_prefix}
+
+%files
+%defattr(-,root,root)
+%{python_sitelib}/*
+%{_bindir}/raetflo
+
+%changelog


### PR DESCRIPTION
Here is the initial suse rpm spec file for creating a python-raet package on OpenSuse
