### PR TITLE
Fix auto-accept test on windows

### DIFF
--- a/raet/lane/stacking.py
+++ b/raet/lane/stacking.py
@@ -134,6 +134,12 @@ class LaneStack(stacking.Stack):
                 self.incStat('unaccepted_source_yard')
                 return
 
+            # sa is None on Windows, Mailslots don't convey their source addresses
+            # So we need to construct a compatible source address from the local's dirpath
+            # and lanename. Use the yarding.Yard.computeHa utility function for this.
+            if sa is None:
+                sa, haDirpath = yarding.Yard.computeHa(self.local.dirpath, self.local.lanename, sn)
+
             try:
                 self.addRemote(yarding.RemoteYard(stack=self, ha=sa)) # sn and sa are assume compat
             except raeting.StackError as ex:


### PR DESCRIPTION
Per @SmithSamuelM's suggestion, create new source address (sa) on the fly when client is Windows, since Windows mailslots don't pass along their source address.  Fixes #37.
