### PR TITLE
Windows tests fix

### DIFF
--- a/raet/keeping.py
+++ b/raet/keeping.py
@@ -17,7 +17,7 @@ except ImportError:
 try:
     import msgpack
 except ImportError:
-    mspack = None
+    msgpack = None
 
 import shutil
 

--- a/raet/road/test/test_keeping.py
+++ b/raet/road/test/test_keeping.py
@@ -660,7 +660,11 @@ class BasicTestCase(unittest.TestCase):
         fallback to ~user/.raet
         '''
         console.terse("{0}\n".format(self.testAltDirpath.__doc__))
-        base = '/var/cache/'
+        if sys.platform == 'win32':
+            base = os.path.join(os.environ['WINDIR'], 'system32')
+        else:
+            base = '/var/cache/'
+
         auto = raeting.autoModes.once
         data = self.createRoadData(name='main',
                                    base=base,
@@ -672,7 +676,7 @@ class BasicTestCase(unittest.TestCase):
         #default ha is ("", raeting.RAET_PORT)
 
         #console.terse("{0} keep dirpath = {1}\n".format(stack.name, stack.keep.dirpath))
-        self.assertTrue(os.path.join('.raet','keep','main') in stack.keep.dirpath)
+        self.assertIn(os.path.join('.raet','keep','main'), stack.keep.dirpath)
         self.assertEqual(stack.ha, ("0.0.0.0", raeting.RAET_PORT))
 
         # test can write

--- a/raet/road/test/test_stacking.py
+++ b/raet/road/test/test_stacking.py
@@ -402,7 +402,7 @@ class BasicTestCase(unittest.TestCase):
         others.append(odict(house="Other", queue="big stuff", bloat=bloat))
         mains.append(odict(house="Main", queue="gig stuff", bloat=bloat))
 
-        self.bidirectional(bk=raeting.bodyKinds.json, mains=mains, others=others)
+        self.bidirectional(bk=raeting.bodyKinds.json, mains=mains, others=others, duration=20.0)
 
     def testSegmentedMsgpack(self):
         '''
@@ -427,7 +427,7 @@ class BasicTestCase(unittest.TestCase):
         others.append(odict(house="Other", queue="big stuff", bloat=bloat))
         mains.append(odict(house="Main", queue="gig stuff", bloat=bloat))
 
-        self.bidirectional(bk=raeting.bodyKinds.msgpack, mains=mains, others=others)
+        self.bidirectional(bk=raeting.bodyKinds.msgpack, mains=mains, others=others, duration=20.0)
 
     def testJoinForever(self):
         '''


### PR DESCRIPTION
With this fixes unit tests passed in Python 2.6 and 2.7 on Windows 7