### PR TITLE
Update version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@ CHANGE LOG
 -----------
 20150310
 ----------
-v0.6.2
+v0.6.3
 
 Changed imports ioflo.base.nonblocking to be compat with ioflo 1.2.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,13 @@ CHANGE LOG
 -------------------
 
 -----------
+20150310
+----------
+v0.6.2
+
+Changed imports ioflo.base.nonblocking to be compat with ioflo 1.2.1
+
+-----------
 20150212
 ----------
 v0.6.1

--- a/raet/__metadata__.py
+++ b/raet/__metadata__.py
@@ -2,7 +2,7 @@
 Raet package metadata
 '''
 
-__version_info__ = (0, 6, 2)
+__version_info__ = (0, 6, 3)
 __version__ = '{0}.{1}.{2}'.format(*__version_info__)
 __author__ = "Samuel M. Smith"
 __license__ = "Apache2"

--- a/raet/lane/stacking.py
+++ b/raet/lane/stacking.py
@@ -25,6 +25,7 @@ except ImportError:
 # Import ioflo libs
 from ioflo.base.odicting import odict
 from ioflo.base import aiding
+from ioflo.base import nonblocking
 from ioflo.base import storing
 
 # Import raet libs
@@ -84,10 +85,10 @@ class LaneStack(stacking.Stack):
         '''
 
         if not sys.platform == 'win32':
-            server = aiding.SocketUxdNb(ha=self.ha,
+            server = nonblocking.SocketUxdNb(ha=self.ha,
                                 bufsize=raeting.UXD_MAX_PACKET_SIZE * self.bufcnt)
         else:
-            server = aiding.WinMailslotNb(ha=self.ha,
+            server = nonblocking.WinMailslotNb(ha=self.ha,
                                 bufsize=raeting.UXD_MAX_PACKET_SIZE * self.bufcnt)
         return server
 

--- a/raet/road/stacking.py
+++ b/raet/road/stacking.py
@@ -24,6 +24,7 @@ except ImportError:
 # Import ioflo libs
 from ioflo.base.odicting import odict
 from ioflo.base import aiding
+from ioflo.base import nonblocking
 from ioflo.base import storing
 
 # Import raet libs
@@ -187,7 +188,7 @@ class RoadStack(stacking.KeepStack):
         '''
         Create local listening server for stack
         '''
-        server = aiding.SocketUdpNb(ha=self.ha,
+        server = nonblocking.SocketUdpNb(ha=self.ha,
                         bufsize=raeting.UDP_MAX_PACKET_SIZE * self.bufcnt)
         return server
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ RAET_METADATA = os.path.join(SETUP_DIRNAME, 'raet', '__metadata__.py')
 # Load the metadata using exec() in order not to trigger raet.__init__ import
 exec(compile(open(RAET_METADATA).read(), RAET_METADATA, 'exec'))
 
-REQUIREMENTS = ['ioflo>=1.1.7',
+REQUIREMENTS = ['ioflo>=1.2.1',
                 'libnacl>=1.4.0',
                 'six>=1.6.1', ]
 


### PR DESCRIPTION
Reorganized ioflo.base.aiding moved the nonblocking io classes to ioflo.base.nonblocking
Left temporary import so can find them in aiding but changed this version of raet to use the new location.

