### PR TITLE
Stale messages logic change

### DIFF
--- a/raet/road/estating.py
+++ b/raet/road/estating.py
@@ -76,6 +76,7 @@ class Estate(lotting.Lot):
         self.dyned = dyned
         self.role = role if role is not None else self.name
         self.transactions = odict() # estate transactions keyed by transaction index
+        self.doneTransactions = odict()  # temporary storage for done transaction ids
 
     @property
     def eha(self):
@@ -142,6 +143,15 @@ class Estate(lotting.Lot):
                     console.concise( "Removed transaction from '{0}' at '{1}',"
                             " instead of at '{2}'\n".format(self.name, i, index))
 
+    def addDoneTransaction(self, index):
+        self.doneTransactions[index] = aiding.StoreTimer(self.stack.store, duration=self.stack.MsgStaleTimeout)
+
+    def cleanupDoneTransactions(self):
+        for index, timer in self.doneTransactions.iteritems():
+            if not timer.expired:
+                break
+            del self.doneTransactions[index]
+            console.verbose("Removed already done transaction from {0} at '{1}'\n".format(self.name, index))
 
     def removeStaleTransactions(self):
         '''
@@ -155,6 +165,7 @@ class Estate(lotting.Lot):
         '''
         for transaction in self.transactions.values():
             transaction.process()
+        self.cleanupDoneTransactions()
 
     @staticmethod
     def nameGuid(prefix='estate'):
@@ -393,6 +404,7 @@ class RemoteEstate(Estate):
                                         self.stack.store.stamp))
                 console.terse(emsg)
                 self.stack.incStat('stale_correspondent')
+        self.doneTransactions.clear()
 
     def replaceStaleInitiators(self):
         '''

--- a/raet/road/stacking.py
+++ b/raet/road/stacking.py
@@ -93,6 +93,7 @@ class RoadStack(stacking.KeepStack):
     Interim = 3600 # stack default for reap timeout
     JoinerTimeout = 5.0 # stack default for joiner transaction timeout
     JoinentTimeout = 5.0 # stack default for joinent transaction timeout
+    MsgStaleTimeout = 600.0  # stale messages waiting timeout
 
     def __init__(self,
                  puid=None,
@@ -624,7 +625,8 @@ class RoadStack(stacking.KeepStack):
 
         if (packet.data['tk'] == TrnsKind.message and
                 packet.data['pk'] == PcktKind.message):
-            if packet.data['af']:  # packet is a stale resend
+            ti = packet.data['ti']
+            if ti in remote.doneTransactions:  # transaction with this ID already handled and removed
                 self.replyStale(packet, remote)
             else:
                 self.replyMessage(packet, remote)

--- a/raet/road/transacting.py
+++ b/raet/road/transacting.py
@@ -225,8 +225,8 @@ class Staler(Initiator):
         except ValueError as ex:
             pkname = None
 
-        emsg = ("Staler '{0}'. Stale transaction '{1}' packet '{2}' from '{3}' "
-               "nacking...\n".format(self.stack.name, tkname, pkname, ha ))
+        emsg = ("Staler '{0}'. Stale transaction '{1}' packet '{2}' from '{3}' in {4} "
+                "nacking...\n".format(self.stack.name, tkname, pkname, ha, self.tid))
         console.terse(emsg)
         self.stack.incStat('stale_correspondent_attempt')
 
@@ -304,8 +304,8 @@ class Stalent(Correspondent):
         except ValueError as ex:
             pkname = None
 
-        emsg = ("Stalent '{0}'. Stale transaction '{1}' packet '{2}' from '{3}' "
-                "nacking ...\n".format(self.stack.name, tkname, pkname, ha ))
+        emsg = ("Stalent '{0}'. Stale transaction '{1}' packet '{2}' from '{3}' in {4} "
+                "nacking ...\n".format(self.stack.name, tkname, pkname, ha, self.tid))
         console.terse(emsg)
         self.stack.incStat('stale_initiator_attempt')
 
@@ -3261,3 +3261,6 @@ class Messengent(Correspondent):
                 self.stack.name, self.remote.name, self.tid, self.stack.store.stamp))
         self.stack.incStat(self.statKey())
 
+    def remove(self, remote=None, index=None):
+        self.remote.addDoneTransaction(self.tid)
+        super(Messengent, self).remove(remote, index)


### PR DESCRIPTION
Don't nack transaction if 1st try lost all message segments:
	- keep done messengent transactions IDs for limited time
	- accept message segment if the tid is known as done
Unit test also added.