### PR TITLE
Fix for problem if all initial segments are dropped

### DIFF
--- a/raet/stacking.py
+++ b/raet/stacking.py
@@ -286,7 +286,6 @@ class Stack(object):
         self.rxes.append((rx, ra))     # duple = ( packet, source address)
         return True
 
-
     def serviceReceives(self):
         '''
         Retrieve from server all recieved and put on the rxes deque

--- a/raet/stacking.py
+++ b/raet/stacking.py
@@ -390,7 +390,6 @@ class Stack(object):
             raise raeting.StackError(msg)
         self.txes.append((packed, self.remotes[duid].ha))
 
-
     def _handleOneTx(self, laters, blocks):
         '''
         Handle one message on .txes deque


### PR DESCRIPTION
Sets .acked attribute whenever receive an ack from messegent. This governs whether or not
the af (again flag) is set in the retry header. If set then if no transaction treat as stale. if not set then create transaction.

