### PR TITLE
Stale with cache

### DIFF
--- a/raet/road/stacking.py
+++ b/raet/road/stacking.py
@@ -625,8 +625,8 @@ class RoadStack(stacking.KeepStack):
 
         if (packet.data['tk'] == TrnsKind.message and
                 packet.data['pk'] == PcktKind.message):
-            ti = packet.data['ti']
-            if ti in remote.doneTransactions:  # transaction with this ID already handled and removed
+            # transaction with this ID already handled and removed packet is a stale resend
+            if packet.data['af'] or packet.data['ti'] in remote.doneTransactions:
                 self.replyStale(packet, remote)
             else:
                 self.replyMessage(packet, remote)


### PR DESCRIPTION
Previously me and Samuel added two different solutions for the issue transaction losing issue, when all segments from the first try are lost and the second try is treated as stale (already handled).

My solution was to cache done transactions temporarily and in case receiver assumes the transaction is stale it should check does it really handled it before by the cache lookup. This solution has a weakness: if a segment delayed for longer time than receiver keeps transactions in the cache. In this case transaction will be handled again.

Sam's solution is to don't set 'again' flag until at least one response received in the scope of a transaction. This is handled by sender. This solution could pass duplications too if sender loss acknowledgement or if receiver gets single-part data twice.

Current code contains both fixes, but Sam's solution isn't properly handled on the receiver side: stack currently doesn't look for 'af' flag on receive. I've implemented two solutions for this issue: one is to keep the only Samuel's solution (#62) and the second one (this one, #61) to use both: the cache and the new 'af' logic that avoids duplications for a cache timeout period.

**Note:** PRs #61 and #62 are mutually exclusive, the only one should be merged.