### PR TITLE
Bugfix: Windows exceptions may not contain 'errno'

### DIFF
--- a/raet/lane/stacking.py
+++ b/raet/lane/stacking.py
@@ -232,13 +232,14 @@ class LaneStack(stacking.Stack):
         except Exception as ex:
             console.concise("Error sending to '{0}' from '{1}: {2}\n".format(
                 ta, self.ha, ex))
-            if ex.errno == errno.ECONNREFUSED or ex.errno == errno.ENOENT:
+            err = raeting.get_exception_error(ex)
+            if err == errno.ECONNREFUSED or err == errno.ENOENT:
                 self.incStat("stale_transmit_yard")
                 yard = self.haRemotes.get(ta)
                 if yard:
                     self.removeRemote(yard)
                     console.terse("Reaped yard {0}\n".format(yard.name))
-            elif ex.errno in [errno.EAGAIN, errno.EWOULDBLOCK, errno.ENOBUFS]:
+            elif err in [errno.EAGAIN, errno.EWOULDBLOCK, errno.ENOBUFS]:
                 self.incStat("busy_transmit_yard")
                 #busy with last message save it for later
                 laters.append((tx, ta))

--- a/raet/lane/yarding.py
+++ b/raet/lane/yarding.py
@@ -113,7 +113,8 @@ class Yard(lotting.Lot):
                         try:
                             os.makedirs(dirpath)
                         except OSError as ex:
-                            if ex.errno == errno.EEXIST:
+                            err = raeting.get_exception_error(ex)
+                            if err == errno.EEXIST:
                                 pass # race condition
                             else:
                                 raise
@@ -124,7 +125,8 @@ class Yard(lotting.Lot):
                         try:
                             os.makedirs(dirpath)
                         except OSError as ex:
-                            if ex.errno == errno.EEXIST:
+                            err = raeting.get_exception_error(ex)
+                            if err == errno.EEXIST:
                                 pass # race condition
                             else:
                                 raise

--- a/raet/raeting.py
+++ b/raet/raeting.py
@@ -137,6 +137,19 @@ INITIATESTUFF_PACKER = struct.Struct('!32s48s24s128s')
 INITIATE_PACKER = struct.Struct('!32s24s248s24s')
 
 
+def get_exception_error(ex):
+    '''
+    Return the error code from an exception
+    '''
+    if hasattr(ex, 'errno'):
+        return ex.errno
+    elif hasattr(ex, 'winerror'):
+        return ex.winerror
+    else:
+        emsg = "Cannot find error code in exception: {0}".format(ex)
+        raise TypeError(emsg)
+
+
 @enum.unique
 class HeadKind(enum.IntEnum):
     '''

--- a/raet/stacking.py
+++ b/raet/stacking.py
@@ -279,7 +279,8 @@ class Stack(object):
         try:
             rx, ra = self.server.receive()  # if no data the duple is ('',None)
         except socket.error as ex:
-            if ex.errno == errno.ECONNRESET:
+            err = raeting.get_exception_error(ex)
+            if err == errno.ECONNRESET:
                 return False
         if not rx:  # no received data
             return False
@@ -406,7 +407,8 @@ class Stack(object):
         try:
             self.server.send(tx, ta)
         except socket.error as ex:
-            if (ex.errno in [errno.EAGAIN, errno.EWOULDBLOCK,
+            err = raeting.get_exception_error(ex)
+            if (err in [errno.EAGAIN, errno.EWOULDBLOCK,
                              errno.ENETUNREACH, errno.ETIME,
                              errno.EHOSTUNREACH, errno.EHOSTDOWN,
                              errno.ECONNRESET]):


### PR DESCRIPTION
An example of this is 'win32file.CreateFile' which contains 'winerror'
instead of 'errno'. This will fix a problem where the error handling
code would itself throw an exception. What is interesting, is that at
least in the case of 'errno.ENOENT', we can use errno values to compare
'winerror' error codes.

Signed-off-by: Sergey Kizunov <sergey.kizunov@ni.com>