### PR TITLE
Don't use kwargs for str.decode()

### DIFF
--- a/raet/flo/test/test_behaving.py
+++ b/raet/flo/test/test_behaving.py
@@ -16,9 +16,7 @@ from ioflo.base.consoling import getConsole
 console = getConsole()
 
 # Import raet libs
-from raet.abiding import *  # import globals
 from raet.road import stacking
-from raet.flo import behaving
 
 def setUpModule():
     console.reinit(verbosity=console.Wordage.concise)

--- a/raet/lane/paging.py
+++ b/raet/lane/paging.py
@@ -111,7 +111,7 @@ class RxHead(Head):
         self.page.body.packed = back
 
         kit = odict()
-        lines = str(front.decode(encoding='ISO-8859-1')).split('\n')
+        lines = str(front.decode('ISO-8859-1')).split('\n')
         for line in lines:
             key, val = line.split(' ')
             if key not in raeting.PAGE_FIELDS:
@@ -192,7 +192,7 @@ class RxBody(Body):
 
         if pk == PackKind.json:
             if self.packed:
-                self.data = json.loads(self.packed.decode(encoding='utf-8'),
+                self.data = json.loads(self.packed.decode('utf-8'),
                                        object_pairs_hook=odict)
         elif pk == PackKind.pack:
             if self.packed:

--- a/raet/nacling.py
+++ b/raet/nacling.py
@@ -573,4 +573,4 @@ def uuid(size=16):
         front = ns2b("{0:0x}".format(int(time.time() * 1000000)))  # microseconds
     extra = size - len(front)
     back = binascii.hexlify(libnacl.randombytes(extra // 2 + extra % 2))
-    return ((front + back)[:size]).decode(encoding='ISO-8859-1')
+    return ((front + back)[:size]).decode('ISO-8859-1')

--- a/raet/road/packeting.py
+++ b/raet/road/packeting.py
@@ -177,7 +177,7 @@ class RxHead(Head):
             front, sep, back = packed.partition(raeting.HEAD_END)
             self.packed = front + sep
             kit = odict()
-            lines = str(front.decode(encoding='ISO-8859-1')).split('\n')
+            lines = str(front.decode('ISO-8859-1')).split('\n')
             for line in lines:
                 key, val = line.split(' ')
                 if key not in raeting.PACKET_HEAD_FIELDS:
@@ -214,7 +214,7 @@ class RxHead(Head):
             hk = HeadKind.json.value
             front, sep, back = packed.partition(raeting.JSON_END)
             self.packed = front + sep
-            kit = json.loads(front.decode(encoding='ascii'),
+            kit = json.loads(front.decode('ascii'),
                              object_pairs_hook=odict)
             data.update(kit)
             if 'fg' in data:
@@ -307,7 +307,7 @@ class RxBody(Body):
 
         if bk == BodyKind.json:
             if self.packed:
-                kit = json.loads(self.packed.decode(encoding='utf-8'),
+                kit = json.loads(self.packed.decode('utf-8'),
                                  object_pairs_hook=odict,
                                  encoding='utf-8')
                 if not isinstance(kit, Mapping):

--- a/raet/road/test/test_packeting.py
+++ b/raet/road/test/test_packeting.py
@@ -542,7 +542,7 @@ class StackTestCase(unittest.TestCase):
         self.assertEqual( tray1.body, self.stuff)
 
         # Json body
-        body = odict(stuff=str(self.stuff.decode(encoding='ISO-8859-1')))
+        body = odict(stuff=str(self.stuff.decode('ISO-8859-1')))
         self.data.update(se=2, de=3, bk=raeting.BodyKind.json.value, fk=raeting.FootKind.nacl.value)
         tray0 = packeting.TxTray(stack=self.main, data=self.data, body=body)
         tray0.pack()


### PR DESCRIPTION
Python 2.6 compatibility fix
Fix for #69 and https://github.com/saltstack/salt/issues/25858
PS: unit tests passed locally on Python 2.6, 2.7 and 3.5.