### PR TITLE
Feature/stacking decomposition

### DIFF
--- a/raet/road/stacking.py
+++ b/raet/road/stacking.py
@@ -338,7 +338,8 @@ class RoadStack(stacking.KeepStack):
                                                 acceptance=keepData['acceptance'],
                                                 verkey=keepData['verhex'],
                                                 pubkey=keepData['pubhex'],
-                                                role=keepData['role'])
+                                                role=keepData['role']),
+                                      addRemote=False
                                       )
                 if remote:
                     self.addRemote(remote)
@@ -372,7 +373,8 @@ class RoadStack(stacking.KeepStack):
                                                     acceptance=keepData['acceptance'],
                                                     verkey=keepData['verhex'],
                                                     pubkey=keepData['pubhex'],
-                                                    role=keepData['role'])
+                                                    role=keepData['role']),
+                                          addRemote=False
                                           )
                     if remote:
                         self.addRemote(remote)
@@ -532,7 +534,7 @@ class RoadStack(stacking.KeepStack):
                             return
 
                         # create vacuous remote will be assigned to joinees in joinent
-                        remote = createRemote(ha=sha)
+                        remote = createRemote(ha=sha, addRemote=False)
 
                 else: # nonvacuous join match by nuid from .remotes
                     remote = self.remotes.get(de, None)
@@ -542,7 +544,7 @@ class RoadStack(stacking.KeepStack):
                                 " Renewing....\n".format( self.name, de, sha))
                         console.terse(emsg)
                         self.incStat('stale_nuid')
-                        remote = createRemote(ha=sha)
+                        remote = createRemote(ha=sha, addRemote=False)
                         if not remote:
                           return
                         self.replyStale(packet, remote, renew=True) # nack stale transaction

--- a/raet/road/stacking.py
+++ b/raet/road/stacking.py
@@ -238,20 +238,19 @@ class RoadStack(stacking.KeepStack):
                 remote = None
         return remote
 
-    def createRemote(self, ha, fuid=0, sid=0, addRemote=True):
+    def createRemote(self, ha, data=dict(), addRemote=True):
         '''
         Use for vacuous join to create new remote
-        Default is always 0 for join
         '''
         if not ha:
             console.terse("Invalid host address = {0} when creating remote.".format(ha))
             self.incStat("failed_createremote")
             return None
 
-        remote = estating.RemoteEstate(stack=self,
-                                       fuid=fuid,
-                                       sid=sid,
-                                       ha=ha) #if ha is not None else dha
+        defaults = dict(ha=ha, fuid=0, sid=0, stack=self)
+        defaults.update(data)
+
+        remote = estating.RemoteEstate(**defaults) #if ha is not None else dha
 
         if addRemote:
             try:
@@ -323,24 +322,26 @@ class RoadStack(stacking.KeepStack):
             if self.keep.verifyRemoteData(keepData):
                 ha = keepData['ha']
                 iha = keepData['iha']
-                remote = estating.RemoteEstate(stack=self,
-                                               uid=keepData['uid'],
-                                               fuid=keepData['fuid'],
-                                               name=keepData['name'],
-                                               ha=tuple(ha) if ha else ha,
-                                               iha=tuple(iha) if iha else iha,
-                                               natted=keepData['natted'],
-                                               fqdn=keepData['fqdn'],
-                                               dyned=keepData['dyned'],
-                                               sid=keepData['sid'],
-                                               main=keepData['main'],
-                                               kind=keepData['kind'],
-                                               joined=keepData['joined'],
-                                               acceptance=keepData['acceptance'],
-                                               verkey=keepData['verhex'],
-                                               pubkey=keepData['pubhex'],
-                                               role=keepData['role'])
-                self.addRemote(remote)
+                remote = createRemote(ha=tuple(ha) if ha else ha,
+                                      data=dict(stack=self,
+                                                uid=keepData['uid'],
+                                                fuid=keepData['fuid'],
+                                                name=keepData['name'],
+                                                iha=tuple(iha) if iha else iha,
+                                                natted=keepData['natted'],
+                                                fqdn=keepData['fqdn'],
+                                                dyned=keepData['dyned'],
+                                                sid=keepData['sid'],
+                                                main=keepData['main'],
+                                                kind=keepData['kind'],
+                                                joined=keepData['joined'],
+                                                acceptance=keepData['acceptance'],
+                                                verkey=keepData['verhex'],
+                                                pubkey=keepData['pubhex'],
+                                                role=keepData['role'])
+                                      )
+                if remote:
+                    self.addRemote(remote)
             else:
                 self.keep.clearRemoteData(name)
         return remote
@@ -355,24 +356,26 @@ class RoadStack(stacking.KeepStack):
                 if self.keep.verifyRemoteData(keepData):
                     ha = keepData['ha']
                     iha = keepData['iha']
-                    remote = estating.RemoteEstate(stack=self,
-                                                   uid=keepData['uid'],
-                                                   fuid=keepData['fuid'],
-                                                   name=keepData['name'],
-                                                   ha=tuple(ha) if ha else ha,
-                                                   iha=tuple(iha) if iha else iha,
-                                                   natted=keepData['natted'],
-                                                   fqdn=keepData['fqdn'],
-                                                   dyned=keepData['dyned'],
-                                                   sid=keepData['sid'],
-                                                   main=keepData['main'],
-                                                   kind=keepData['kind'],
-                                                   joined=keepData['joined'],
-                                                   acceptance=keepData['acceptance'],
-                                                   verkey=keepData['verhex'],
-                                                   pubkey=keepData['pubhex'],
-                                                   role=keepData['role'])
-                    self.addRemote(remote)
+                    remote = createRemote(ha=tuple(ha) if ha else ha,
+                                          data=dict(stack=self,
+                                                    uid=keepData['uid'],
+                                                    fuid=keepData['fuid'],
+                                                    name=keepData['name'],
+                                                    iha=tuple(iha) if iha else iha,
+                                                    natted=keepData['natted'],
+                                                    fqdn=keepData['fqdn'],
+                                                    dyned=keepData['dyned'],
+                                                    sid=keepData['sid'],
+                                                    main=keepData['main'],
+                                                    kind=keepData['kind'],
+                                                    joined=keepData['joined'],
+                                                    acceptance=keepData['acceptance'],
+                                                    verkey=keepData['verhex'],
+                                                    pubkey=keepData['pubhex'],
+                                                    role=keepData['role'])
+                                          )
+                    if remote:
+                        self.addRemote(remote)
                 else:
                     self.keep.clearRemoteData(name)
 
@@ -529,9 +532,7 @@ class RoadStack(stacking.KeepStack):
                             return
 
                         # create vacuous remote will be assigned to joinees in joinent
-                        remote = createRemote(fuid=0,  # was fuid=se
-                                              sid=rsid,
-                                              ha=sha)
+                        remote = createRemote(ha=sha)
 
                 else: # nonvacuous join match by nuid from .remotes
                     remote = self.remotes.get(de, None)
@@ -541,9 +542,7 @@ class RoadStack(stacking.KeepStack):
                                 " Renewing....\n".format( self.name, de, sha))
                         console.terse(emsg)
                         self.incStat('stale_nuid')
-                        remote = createRemote(fuid=se,
-                                              sid=rsid,
-                                              ha=sha)
+                        remote = createRemote(ha=sha)
                         if not remote:
                           return
                         self.replyStale(packet, remote, renew=True) # nack stale transaction


### PR DESCRIPTION
In certain systems people may want to add additional checks upon creation a remote. For example people may want to accept joins only from the nodes in a certain registry. With this kind of decomposition it would be easy to override just one method createRemote to introduce any desired validation.