### PR TITLE
Feature Request: Use newRemote wrapper for creating remotes

### DIFF
--- a/raet/road/stacking.py
+++ b/raet/road/stacking.py
@@ -262,6 +262,7 @@ class RoadStack(stacking.KeepStack):
         return remote
 
     def newRemote(self, **kwa):
+      # override to add additional kwa validations
     	return estating.RemoteEstate(**kwa)
 
     def dumpLocalRole(self):

--- a/raet/road/stacking.py
+++ b/raet/road/stacking.py
@@ -338,7 +338,8 @@ class RoadStack(stacking.KeepStack):
                                                 acceptance=keepData['acceptance'],
                                                 verkey=keepData['verhex'],
                                                 pubkey=keepData['pubhex'],
-                                                role=keepData['role'])
+                                                role=keepData['role']),
+                                      addRemote=False
                                       )
                 if remote:
                     self.addRemote(remote)
@@ -372,7 +373,8 @@ class RoadStack(stacking.KeepStack):
                                                     acceptance=keepData['acceptance'],
                                                     verkey=keepData['verhex'],
                                                     pubkey=keepData['pubhex'],
-                                                    role=keepData['role'])
+                                                    role=keepData['role']),
+                                          addRemote=False
                                           )
                     if remote:
                         self.addRemote(remote)
@@ -532,7 +534,7 @@ class RoadStack(stacking.KeepStack):
                             return
 
                         # create vacuous remote will be assigned to joinees in joinent
-                        remote = createRemote(ha=sha)
+                        remote = createRemote(ha=sha, addRemote=False)
 
                 else: # nonvacuous join match by nuid from .remotes
                     remote = self.remotes.get(de, None)
@@ -542,7 +544,7 @@ class RoadStack(stacking.KeepStack):
                                 " Renewing....\n".format( self.name, de, sha))
                         console.terse(emsg)
                         self.incStat('stale_nuid')
-                        remote = createRemote(ha=sha)
+                        remote = createRemote(ha=sha, addRemote=False)
                         if not remote:
                           return
                         self.replyStale(packet, remote, renew=True) # nack stale transaction

--- a/raet/road/stacking.py
+++ b/raet/road/stacking.py
@@ -251,6 +251,7 @@ class RoadStack(stacking.KeepStack):
  								fuid=0, # vacuous join
  								sid=0, # always 0 for join
 								ha=ha) #if ha is not None else dha
+        
         try:
             self.addRemote(remote) #provisionally add .accepted is None
         except raeting.StackError as ex:
@@ -324,7 +325,7 @@ class RoadStack(stacking.KeepStack):
                 ha = keepData['ha']
                 iha = keepData['iha']
                 remote = self.newRemote(ha=tuple(ha) if ha else ha,
-										stack=self,
+                                        stack=self,
 	                                    uid=keepData['uid'],
 	                                    fuid=keepData['fuid'],
 	                                    name=keepData['name'],
@@ -357,7 +358,7 @@ class RoadStack(stacking.KeepStack):
                     ha = keepData['ha']
                     iha = keepData['iha']
                     remote = self.newRemote(ha=tuple(ha) if ha else ha,
-											stack=self,
+                                            stack=self,
                                             uid=keepData['uid'],
                                             fuid=keepData['fuid'],
                                             name=keepData['name'],
@@ -532,9 +533,9 @@ class RoadStack(stacking.KeepStack):
 
                         # create vacuous remote will be assigned to joinees in joinent
                         remote = self.newRemote(stack=self,
-                        						fuid=0,  # was fuid=se
- 												sid=rsid,
-												ha=sha)
+                                                fuid=0,  # was fuid=se
+                                                sid=rsid,
+                                                ha=sha)
 
                 else: # nonvacuous join match by nuid from .remotes
                     remote = self.remotes.get(de, None)
@@ -545,9 +546,9 @@ class RoadStack(stacking.KeepStack):
                         console.terse(emsg)
                         self.incStat('stale_nuid')
                         remote = self.newRemote(stack=self,
-                        						fuid=se,
- 												sid=rsid,
-												ha=sha)
+                                                fuid=se,
+                                                sid=rsid,
+                                                ha=sha)
                         if not remote:
                           return
 

--- a/raet/road/stacking.py
+++ b/raet/road/stacking.py
@@ -262,7 +262,10 @@ class RoadStack(stacking.KeepStack):
         return remote
 
     def newRemote(self, **kwa):
-      # override to add additional kwa validations
+      '''
+      Used as a wrapper to create new remotes
+      Override to add additional kwa validations
+      '''
     	return estating.RemoteEstate(**kwa)
 
     def dumpLocalRole(self):

--- a/raet/road/stacking.py
+++ b/raet/road/stacking.py
@@ -248,9 +248,9 @@ class RoadStack(stacking.KeepStack):
             return None
 
         remote = self.newRemote(stack=self,
- 								fuid=0, # vacuous join
- 								sid=0, # always 0 for join
-								ha=ha) #if ha is not None else dha
+                                fuid=0, # vacuous join
+                                sid=0, # always 0 for join
+                                ha=ha) #if ha is not None else dha
         
         try:
             self.addRemote(remote) #provisionally add .accepted is None


### PR DESCRIPTION
Original:
In certain systems people may want to add additional checks upon creation a remote. For example people may want to accept joins only from the nodes in a certain registry. With this kind of decomposition it would be easy to override just one method createRemote to introduce any desired validation.

Update:
Created a dedicated wrapper as discussed

Please update pypi package once merged