### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The architecture of a RAET based application is shown in the figure below:
 
 ![Diagram 1](docs/images/RaetMetaphor.png?raw=true)
 
-##Naming Metaphor for Components
+## Naming Metaphor for Components
 
 The following naming metaphor is designed to consistent but not conflicting with Ioflo
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
